### PR TITLE
Includes try/catch

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for MooseX-Extended
 
 {{$NEXT}}
 
+          - Optional Syntax::Keyword::Try support
           - Rename repo from moosex-extreme to moosex-extended
 
 0.26      2022-07-29 08:28:21 CEST

--- a/README.md
+++ b/README.md
@@ -286,6 +286,27 @@ features you can use for this. They're turned by the `includes` flag.
 
     Only available on Perl v5.26.0 or higher. Requires [Future::AsyncAwait](https://metacpan.org/pod/Future%3A%3AAsyncAwait).
 
+- `try`
+
+    ```perl
+    package My::Try {
+        use MooseX::Extended includes => [qw/try/];
+
+        sub reciprocal ( $self, $num ) {
+            try {
+                return 1 / $num;
+            }
+            catch {
+                croak "Could not calculate reciprocal of $num: $@";
+            }
+        }
+    }
+    ```
+
+    Allows you to use try/catch blocks, via [Syntax::Keyword::Try](https://metacpan.org/pod/Syntax%3A%3AKeyword%3A%3ATry).
+
+    Only available on Perl v5.24.0 or higher. Requires [Syntax::Keyword::Try](https://metacpan.org/pod/Syntax%3A%3AKeyword%3A%3ATry).
+
 # REDUCING BOILERPLATE
 
 Let's say you've settled on the following feature set:

--- a/cpanfile
+++ b/cpanfile
@@ -34,7 +34,7 @@ requires "true" => "v1.0.2";
 requires "warnings" => "0";
 suggests "Future::AsyncAwait" => "0.58";
 suggests "Syntax::Keyword::MultiSub" => "0.02";
-suggests "Syntax::Keyword::Try" => "0.026";
+suggests "Syntax::Keyword::Try" => "0.027";
 
 on 'test' => sub {
   requires "Capture::Tiny" => "0";

--- a/cpanfile
+++ b/cpanfile
@@ -34,6 +34,7 @@ requires "true" => "v1.0.2";
 requires "warnings" => "0";
 suggests "Future::AsyncAwait" => "0.58";
 suggests "Syntax::Keyword::MultiSub" => "0.02";
+suggests "Syntax::Keyword::Try" => "0.026";
 
 on 'test' => sub {
   requires "Capture::Tiny" => "0";

--- a/dist.ini
+++ b/dist.ini
@@ -47,7 +47,7 @@ Perl::Critic::Policy::Moose::RequireMakeImmutable  = 0    ; for xt tests
 [Prereqs / RuntimeSuggests]
 -relationship = suggests
 Syntax::Keyword::MultiSub = 0.02
-Syntax::Keyword::Try      = 0.026
+Syntax::Keyword::Try      = 0.027
 Future::AsyncAwait        = 0.58
 
 [Prereqs / TestRecommends]

--- a/dist.ini
+++ b/dist.ini
@@ -47,6 +47,7 @@ Perl::Critic::Policy::Moose::RequireMakeImmutable  = 0    ; for xt tests
 [Prereqs / RuntimeSuggests]
 -relationship = suggests
 Syntax::Keyword::MultiSub = 0.02
+Syntax::Keyword::Try      = 0.026
 Future::AsyncAwait        = 0.58
 
 [Prereqs / TestRecommends]

--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -359,6 +359,25 @@ Allows you to write asynchronous code with C<async> and C<await>.
 
 Only available on Perl v5.26.0 or higher. Requires L<Future::AsyncAwait>.
 
+=item * C<try>
+
+    package My::Try {
+        use MooseX::Extended includes => [qw/try/];
+
+        sub reciprocal ( $self, $num ) {
+            try {
+                return 1 / $num;
+            }
+            catch {
+                croak "Could not calculate reciprocal of $num: $@";
+            }
+        }
+    }
+
+Allows you to use try/catch blocks, via L<Syntax::Keyword::Try>.
+
+Only available on Perl v5.24.0 or higher. Requires L<Syntax::Keyword::Try>.
+
 =back
 
 =head1 REDUCING BOILERPLATE

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -236,7 +236,7 @@ sub _apply_optional_features ( $config, $for_class ) {
         load Future::AsyncAwait;
         Future::AsyncAwait->import::into($for_class);
     }
-    if ( $config->{includes}{multi} ) {
+    if ( $config->{includes}{try} ) {
         if ( $^V && $^V lt v5.24.0 ) {
             croak("try/catch not supported in Perl version less than v5.24.0. You have $^V");
         }

--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -209,6 +209,7 @@ sub _default_import_list () {
                     qw/
                       multi
                       async
+                      try
                       /
                 ]
             ]
@@ -234,6 +235,15 @@ sub _apply_optional_features ( $config, $for_class ) {
         # don't trap the error. Let it bubble up.
         load Future::AsyncAwait;
         Future::AsyncAwait->import::into($for_class);
+    }
+    if ( $config->{includes}{multi} ) {
+        if ( $^V && $^V lt v5.24.0 ) {
+            croak("try/catch not supported in Perl version less than v5.24.0. You have $^V");
+        }
+
+        # don't trap the error. Let it bubble up.
+        load Syntax::Keyword::Try;
+        Syntax::Keyword::Try->import::into($for_class);
     }
 }
 

--- a/lib/MooseX/Extended/Role.pm
+++ b/lib/MooseX/Extended/Role.pm
@@ -205,6 +205,25 @@ Allows you to write asynchronous code with C<async> and C<await>.
 
 Only available on Perl v5.26.0 or higher. Requires L<Future::AsyncAwait>.
 
+=item * C<try>
+
+    package My::Try {
+        use MooseX::Extended includes => [qw/try/];
+
+        sub reciprocal ( $self, $num ) {
+            try {
+                return 1 / $num;
+            }
+            catch {
+                croak "Could not calculate reciprocal of $num: $@";
+            }
+        }
+    }
+
+Allows you to use try/catch blocks, via L<Syntax::Keyword::Try>.
+
+Only available on Perl v5.24.0 or higher. Requires L<Syntax::Keyword::Try>.
+
 =back
 
 =head1 IDENTICAL METHOD NAMES IN CLASSES AND ROLES

--- a/t/multimethods.t
+++ b/t/multimethods.t
@@ -50,7 +50,7 @@ my %cases = (
 );
 
 while ( my ( $name, $class ) = each %cases ) {
-    subtest "Multi in classes" => sub {
+    subtest "Multi in $name" => sub {
         ok my $multi = $class->new, "We should be allowed to load $name with multimethods";
 
         subtest '2d point' => sub {

--- a/t/stringy-eval.t
+++ b/t/stringy-eval.t
@@ -1,3 +1,5 @@
+#!/usr/bin/env perl
+
 use strict;
 use Test::More;
 
@@ -20,7 +22,5 @@ BEGIN {
 		ok( !$e, "Local::Role$i compiled ok" ) or diag( "Got: $e" );
 	}
 };
-
-ok 1;
 
 done_testing;

--- a/t/try.t
+++ b/t/try.t
@@ -1,23 +1,10 @@
 #!/usr/bin/env perl
 
-use Test::Most;
-use Module::Load 'load';
-
-BEGIN {
-    # do this in a BEGIN  block to exit early. Otherwise, the rest of
-    # the code won't even compile if we don't have Syntax::Keyword::Try
-    # installed.
-    if ( $^V && $^V lt v5.24.0 ) {
-        plan skip_all => 'Version v5.24.0 or greater required for try/catch support';
-    }
-    eval {
-        load Syntax::Keyword::Try;
-        1;
-    } or do {
-        my $error = $@ || "<unknown error>";
-        plan skip_all => "Could not load Syntax::Keyword::Try $error";
-    };
-}
+use lib 't/lib';
+use MooseX::Extended::Tests
+  name    => 'try/catch',
+  module  => 'Syntax::Keyword::Try',
+  version => v5.24.0;
 
 package My::Try {
     use MooseX::Extended includes => [qw/try/];

--- a/t/try.t
+++ b/t/try.t
@@ -27,7 +27,11 @@ package My::Try {
             return 1 / $num;
         }
         catch {
-            croak "Could not calculate reciprocal of $num: $@";
+            # this was a croak(), but by returning the error message (bad
+            # practice, this is just for debugging), I could guarantee that
+            # I'm not throwing an error and thus see if the catch was working.
+            # Currently, the exception is not trapped.
+            return "Could not calculate reciprocal of $num: $@";
         }
     }
 }
@@ -40,7 +44,11 @@ package My::Try::Role {
             return 1 / $num;
         }
         catch {
-            croak "Could not calculate reciprocal of $num: $@";
+            # this was a croak(), but by returning the error message (bad
+            # practice, this is just for debugging), I could guarantee that
+            # I'm not throwing an error and thus see if the catch was working.
+            # Currently, the exception is not trapped.
+            return "Could not calculate reciprocal of $num: $@";
         }
     }
 }

--- a/t/try.t
+++ b/t/try.t
@@ -8,7 +8,7 @@ BEGIN {
     # the code won't even compile if we don't have Syntax::Keyword::Try
     # installed.
     if ( $^V && $^V lt v5.24.0 ) {
-        plan skip_all => 'Version v5.24.0 or greater required for multimethod support';
+        plan skip_all => 'Version v5.24.0 or greater required for try/catch support';
     }
     eval {
         load Syntax::Keyword::Try;
@@ -31,7 +31,7 @@ package My::Try {
             # practice, this is just for debugging), I could guarantee that
             # I'm not throwing an error and thus see if the catch was working.
             # Currently, the exception is not trapped.
-            return "Could not calculate reciprocal of $num: $@";
+            croak "Could not calculate reciprocal of $num: $@";
         }
     }
 }
@@ -48,7 +48,7 @@ package My::Try::Role {
             # practice, this is just for debugging), I could guarantee that
             # I'm not throwing an error and thus see if the catch was working.
             # Currently, the exception is not trapped.
-            return "Could not calculate reciprocal of $num: $@";
+            croak "Could not calculate reciprocal of $num: $@";
         }
     }
 }

--- a/t/try.t
+++ b/t/try.t
@@ -1,0 +1,70 @@
+#!/usr/bin/env perl
+
+use Test::Most;
+use Module::Load 'load';
+
+BEGIN {
+    # do this in a BEGIN  block to exit early. Otherwise, the rest of
+    # the code won't even compile if we don't have Syntax::Keyword::Try
+    # installed.
+    if ( $^V && $^V lt v5.24.0 ) {
+        plan skip_all => 'Version v5.24.0 or greater required for multimethod support';
+    }
+    eval {
+        load Syntax::Keyword::Try;
+        1;
+    } or do {
+        my $error = $@ || "<unknown error>";
+        plan skip_all => "Could not load Syntax::Keyword::Try $error";
+    };
+}
+
+package My::Try {
+    use MooseX::Extended includes => [qw/try/];
+
+    sub reciprocal ( $self, $num ) {
+        try {
+            return 1 / $num;
+        }
+        catch {
+            croak "Could not calculate reciprocal of $num: $@";
+        }
+    }
+}
+
+package My::Try::Role {
+    use MooseX::Extended::Role includes => [qw/try/];
+
+    sub reciprocal ( $self, $num ) {
+        try {
+            return 1 / $num;
+        }
+        catch {
+            croak "Could not calculate reciprocal of $num: $@";
+        }
+    }
+}
+
+package My::Class::Consuming::The::Role {
+    use MooseX::Extended;
+    with 'My::Try::Role';
+}
+
+my %cases = (
+    classes => 'My::Try',
+    roles   => 'My::Class::Consuming::The::Role',
+);
+
+while ( my ( $name, $class ) = each %cases ) {
+    subtest "try in $name" => sub {
+        ok my $try = $class->new, "We should be allowed to load $name with try/catch";
+
+        is $try->reciprocal(2), .5, 'Our try block should be able to return a value';
+
+        throws_ok { $try->reciprocal(0); }
+        qr/Could not calculate reciprocal of.*Illegal division by zero/,
+          '... and our catch block should be able to trap the error';
+    };
+}
+
+done_testing;

--- a/t/try.t
+++ b/t/try.t
@@ -27,10 +27,6 @@ package My::Try {
             return 1 / $num;
         }
         catch {
-            # this was a croak(), but by returning the error message (bad
-            # practice, this is just for debugging), I could guarantee that
-            # I'm not throwing an error and thus see if the catch was working.
-            # Currently, the exception is not trapped.
             croak "Could not calculate reciprocal of $num: $@";
         }
     }
@@ -44,10 +40,6 @@ package My::Try::Role {
             return 1 / $num;
         }
         catch {
-            # this was a croak(), but by returning the error message (bad
-            # practice, this is just for debugging), I could guarantee that
-            # I'm not throwing an error and thus see if the catch was working.
-            # Currently, the exception is not trapped.
             croak "Could not calculate reciprocal of $num: $@";
         }
     }


### PR DESCRIPTION
This is an experimental attempt to add optional try/catch support to MooseX::Extended.

We import the features via `Syntax::Keyword::Try->import::into($target_class)`. This previously worked with `Syntax::Keyword::MultiSub`, so I hoped it would work here. It did not.

In the tests, we have this:

```perl
package My::Try {
    use MooseX::Extended includes => [qw/try/];

    sub reciprocal ( $self, $num ) {
        try {
            return 1 / $num;
        }
        catch {
            # this was a croak(), but by returning the error message (bad
            # practice, this is just for debugging), I could guarantee that
            # I'm not throwing an error and thus see if the catch was working.
            # Currently, the exception is not trapped.
            return "Could not calculate reciprocal of $num: $@";
        }
    }
}
```

However, we're getting an exception thrown from the `catch`. It's not catching the error. Thus, I've missed something. This is on v5.36.0. 

My suspicion is that the try/catch keywords are not being imported at all.