### PR TITLE
Simplify type handling

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for MooseX-Extended
 {{$NEXT}}
 
           - :Standard :String and :Numeric tags are now available for types
+          - Make sure all Type::Params utility functions are available
           - Single arguments to includes, excludes, or types may be simple
             strings and no longer require an array reference.
 

--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for MooseX-Extended
 
 {{$NEXT}}
 
+          - :Standard :String and :Numeric tags are now available for types
           - Single arguments to includes, excludes, or types may be simple
             strings and no longer require an array reference.
 

--- a/README.md
+++ b/README.md
@@ -249,8 +249,9 @@ Let's say you've settled on the following feature set:
 
 ```perl
 use MooseX::Extended
-    excludes => [qw/StrictConstructor carp/],
-    includes => 'method';
+  excludes => [qw/StrictConstructor carp/],
+  includes => 'method',
+  types    => ':Standard';
 ```
 
 And you keep typing that over and over. We've removed a lot of boilerplate,

--- a/lib/MooseX/Extended.pm
+++ b/lib/MooseX/Extended.pm
@@ -6,7 +6,6 @@ use 5.20.0;
 use warnings;
 
 use Moose::Exporter;
-use MooseX::Extended::Types ':all';
 use Moose                     ();
 use MooseX::StrictConstructor ();
 use mro                       ();
@@ -321,8 +320,9 @@ See L<MooseX::Extended::Manual::Includes> for more information.
 Let's say you've settled on the following feature set:
 
     use MooseX::Extended
-        excludes => [qw/StrictConstructor carp/],
-        includes => 'method';
+      excludes => [qw/StrictConstructor carp/],
+      includes => 'method',
+      types    => ':Standard';
 
 And you keep typing that over and over. We've removed a lot of boilerplate,
 but we've added different boilerplate. Instead, just create

--- a/lib/MooseX/Extended/Role.pm
+++ b/lib/MooseX/Extended/Role.pm
@@ -5,7 +5,6 @@ package MooseX::Extended::Role;
 use strict;
 use warnings;
 use Moose::Exporter;
-use MooseX::Extended::Types ':all';
 use MooseX::Extended::Core qw(
   field
   param

--- a/lib/MooseX/Extended/Types.pm
+++ b/lib/MooseX/Extended/Types.pm
@@ -6,7 +6,22 @@ use strict;
 use warnings;
 use Type::Library -base;
 use Type::Utils -all;
-use Type::Params;    # this gets us compile and compile_named
+
+# there is no :all, so we need to hardcode the list
+use Type::Params qw(
+  compile
+  compile_named
+  multisig
+  validate
+  validate_named
+  compile_named_oo
+  Invocant
+  wrap_subs
+  wrap_methods
+  ArgsObject
+);
+
+# EXPORT_OK, but not :all
 use Types::Standard qw(
   slurpy
 );
@@ -21,11 +36,14 @@ BEGIN {
       Types::Common::String
     );
     push @EXPORT_OK => (
-        'compile',          # from Type::Params
-        'compile_named',    # from Type::Params
-        'slurpy',
+        @Type::Params::EXPORT, @Type::Params::EXPORT_OK,
     );
-    our %EXPORT_TAGS = ( all => \@EXPORT_OK );
+    our %EXPORT_TAGS = (
+        all      => \@EXPORT_OK,
+        Standard => [ Types::Standard->type_names ],
+        Numeric  => [ qw/Num Int Bool/, Types::Common::Numeric->type_names ],
+        String   => [ qw/Str/,          Types::Common::String->type_names ],
+    );
 }
 
 1;
@@ -79,9 +97,48 @@ We automatically include the types from the following:
 
 =item * L<Types::Standard>
 
+You can import them individually or with the C<:Standard> tag:
+
+    use MooseX::Extended::Types types => 'Str';
+    use MooseX::Extended::Types types => [ 'Str', 'ArrayRef' ];
+    use MooseX::Extended::Types types => ':Standard';
+
+Using the C<:Standard> tag is equivalent to:
+
+    use Types::Standard;
+
+No import list is supplied directly to the module, so non-default type
+functions must be asked for by name.
+
 =item * L<Types::Common::Numeric>
 
+You can import them individually or with the C<:Numeric> tag:
+
+    use MooseX::Extended::Types types => 'Int';
+    use MooseX::Extended::Types types => [ 'Int', 'NegativeOrZeroNum' ];
+    use MooseX::Extended::Types types => ':Numeric';
+
+Using the C<:Numeric> tag is equivalent to:
+
+    use Types::Common::Numeric;
+
+No import list is supplied directly to the module, so non-default type
+functions must be asked for by name.
+
 =item * L<Types::Common::String>
+
+You can import them individually or with the C<:String> tag:
+
+    use MooseX::Extended::Types types => 'NonEmptyStr';
+    use MooseX::Extended::Types types => [ 'NonEmptyStr', 'UpperCaseStr' ];
+    use MooseX::Extended::Types types => ':String';
+
+Using the C<:String> tag is equivalent to:
+
+    use Types::Common::String;
+
+No import list is supplied directly to the module, so non-default type
+functions must be asked for by name.
 
 =back
 
@@ -98,6 +155,39 @@ See L<Type::Params>
 =item * C<compile_named>
 
 See L<Type::Params>
+
+=item * C<multisig>
+
+See L<Type::Params>
+
+=item * C<validate>
+
+See L<Type::Params>
+
+=item * C<validate_named>
+
+See L<Type::Params>
+
+=item * C<compile_named_oo>
+
+See L<Type::Params>
+
+=item * C<Invocant>
+
+See L<Type::Params>
+
+=item * C<wrap_subs>
+
+See L<Type::Params>
+
+=item * C<wrap_methods>
+
+See L<Type::Params>
+
+=item * C<ArgsObject>
+
+See L<Type::Params>
+
 
 =item * C<slurpy>
 

--- a/lib/MooseX/Extended/Types.pm
+++ b/lib/MooseX/Extended/Types.pm
@@ -36,7 +36,9 @@ BEGIN {
       Types::Common::String
     );
     push @EXPORT_OK => (
-        @Type::Params::EXPORT, @Type::Params::EXPORT_OK,
+        @Type::Params::EXPORT,
+        @Type::Params::EXPORT_OK,
+        @Types::Standard::EXPORT_OK,
     );
     our %EXPORT_TAGS = (
         all      => \@EXPORT_OK,
@@ -76,6 +78,12 @@ As a convenience, if you're using L<MooseX::Extended>, you can do this:
       Str
       compile
     )];
+
+If you're brave:
+
+    use MooseX::Extended types => ':all';
+
+But that exports I<everything> and it's easy to have surprising conflicts.
 
 =head1 DESCRIPTION
 
@@ -144,53 +152,39 @@ functions must be asked for by name.
 
 =head1 EXTRAS
 
-The following extra functions are exported on demand or if use the C<:all> export tag.
+The following extra functions are exported on demand or if using the C<:all>
+export tag (but you probably don't want to use that tag).
+
+=head2 L<Type::Params>
 
 =over
 
 =item * C<compile>
 
-See L<Type::Params>
-
 =item * C<compile_named>
-
-See L<Type::Params>
 
 =item * C<multisig>
 
-See L<Type::Params>
-
 =item * C<validate>
-
-See L<Type::Params>
 
 =item * C<validate_named>
 
-See L<Type::Params>
-
 =item * C<compile_named_oo>
-
-See L<Type::Params>
 
 =item * C<Invocant>
 
-See L<Type::Params>
-
 =item * C<wrap_subs>
-
-See L<Type::Params>
 
 =item * C<wrap_methods>
 
-See L<Type::Params>
-
 =item * C<ArgsObject>
 
-See L<Type::Params>
+=back
 
+=head2 L<Types::Standard>
+
+=over 4
 
 =item * C<slurpy>
-
-See L<Types::Standard>
 
 =back

--- a/t/basic.t
+++ b/t/basic.t
@@ -4,7 +4,7 @@ use lib 't/lib';
 use MooseX::Extended::Tests;
 
 package My::Names {
-    use MooseX::Extended types => [qw(compile Num NonEmptyStr Str PositiveInt ArrayRef)];
+    use MooseX::Extended types => ':all';
     use List::Util 'sum';
 
     param _name => ( isa => NonEmptyStr, init_arg => 'name' );

--- a/t/types.t
+++ b/t/types.t
@@ -1,0 +1,78 @@
+#!/usr/bin/env perl
+
+use lib 't/lib';
+use MooseX::Extended::Tests;
+
+package My::Standard {
+    use MooseX::Extended types => [ ':Standard', 'compile' ];
+    use List::Util 'sum';
+
+    param name => ( isa => Str );
+    param int  => ( isa => Int );
+
+    sub add ( $self, $args ) {
+        state $check = compile( ArrayRef [Num] );
+        ($args) = $check->($args);
+        return sum( $args->@* );
+    }
+}
+
+subtest 'Types::Standard' => sub {
+    my $object = My::Standard->new(
+        name => 'example',
+        int  => 42,
+    );
+    is $object->name,                     'example', 'We should be able to import basic :Standard types';
+    is $object->int,                      42,        '... and they work as expected';
+    is $object->add( [ 4, .5, .5, -3 ] ), 2,         '... and we can combine this with other imported functions';
+};
+
+package My::Numeric {
+    use MooseX::Extended types => [ ':Numeric', qw/compile ArrayRef/ ];
+    use List::Util 'sum';
+
+    param int          => ( isa => Int );
+    param negative_num => ( isa => NegativeNum );
+
+    sub add ( $self, $args ) {
+        state $check = compile( ArrayRef [ Num, 1 ] );
+        ($args) = $check->($args);
+        return sum( $args->@* );
+    }
+}
+
+subtest 'Types::Common::Numeric' => sub {
+    my $object = My::Numeric->new(
+        int          => 4,
+        negative_num => -3.14,
+    );
+    is $object->int,                      4,     'We should be able to import basic :Numeric types';
+    is $object->negative_num,             -3.14, '... and the extended ones';
+    is $object->add( [ 4, .5, .5, -3 ] ), 2,     '... and we can combine this with other imported functions';
+};
+
+package My::String {
+    use MooseX::Extended types => [ ':String', qw/compile ArrayRef Num/ ];
+    use List::Util 'sum';
+
+    param num  => ( isa => Num );
+    param name => ( isa => NonEmptyStr );
+
+    sub add ( $self, $args ) {
+        state $check = compile( ArrayRef [ Num, 1 ] );
+        ($args) = $check->($args);
+        return sum( $args->@* );
+    }
+}
+
+subtest 'Types::Common::String' => sub {
+    my $object = My::String->new(
+        name => 'example',
+        num  => -3.14,
+    );
+    is $object->name,                     'example', 'We should be able to import basic :String types';
+    is $object->num,                      -3.14,     '... or additional types we explicitly name';
+    is $object->add( [ 4, .5, .5, -3 ] ), 2,         '... and we can combine this with other imported functions';
+};
+
+done_testing;


### PR DESCRIPTION
You can now import type groups:

```perl
use MooseX::Extended types => ':Standard';
use MooseX::Extended types => ':String';
use MooseX::Extended types => ':Numeric';
use MooseX::Extended types => [':Standard', ':Numeric', 'compile'];
```