### PR TITLE
Fix the try include in recent perl

### DIFF
--- a/lib/MooseX/Extended/Core.pm
+++ b/lib/MooseX/Extended/Core.pm
@@ -268,7 +268,7 @@ sub _apply_optional_features ( $config, $for_class ) {
             module  => 'Syntax::Keyword::Try',
             skip    => sub ($for_class) {
                 if (HAVE_FEATURE_TRY) {
-                    feature->import::into($for_class);
+                    feature->import::into($for_class, 'try');
                     warnings->unimport('experimental::try');
                     return 1;
                 }

--- a/lib/MooseX/Extended/Manual/Includes.pod
+++ b/lib/MooseX/Extended/Manual/Includes.pod
@@ -131,8 +131,8 @@ Only available on Perl v5.26.0 or higher. Requires L<Future::AsyncAwait>.
             try {
                 return 1 / $num;
             }
-            catch {
-                croak "Could not calculate reciprocal of $num: $@";
+            catch ($e) {
+                croak "Could not calculate reciprocal of $num: $e";
             }
         }
     }

--- a/t/try.t
+++ b/t/try.t
@@ -13,8 +13,8 @@ package My::Try {
         try {
             return 1 / $num;
         }
-        catch {
-            croak "Could not calculate reciprocal of $num: $@";
+        catch ($e) {
+            croak "Could not calculate reciprocal of $num: $e";
         }
     }
 }
@@ -26,8 +26,8 @@ package My::Try::Role {
         try {
             return 1 / $num;
         }
-        catch {
-            croak "Could not calculate reciprocal of $num: $@";
+        catch ($e) {
+            croak "Could not calculate reciprocal of $num: $e";
         }
     }
 }


### PR DESCRIPTION
This breaks in perl 5.36.0 :
```bash
perl -e 'use MooseX::Extended includes => "try"'
No features specified at (eval 452) line 2.
BEGIN failed--compilation aborted at -e line 3.
$
```
The test suite has some failures on perl 5.36 too  : 

```
t/import-lists.t .......... No features specified at (eval 481) line 2.
BEGIN failed--compilation aborted at t/import-lists.t line 14.
Dubious, test returned 2 (wstat 512, 0x200)
No subtests run 

t/try.t ................... No features specified at (eval 480) line 2.
BEGIN failed--compilation aborted at t/try.t line 10.
Dubious, test returned 2 (wstat 512, 0x200)
No subtests run 
```

Seems like a very simple fix to the `Core` module.

Also we would probably need to change the syntax for the `try/catch` block in the tests and the docs, since Perl now insists on having the error assigned to a lexical variable rather than to `$@` (this syntax is supported in `Syntax::Keyword::Try` as well).

 